### PR TITLE
feat: add peerDependenciesMeta

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,14 @@
         "less": "^3.13.1 || ^4.1.1",
         "sass": "^1.32.8"
     },
+    "peerDependenciesMeta": {
+        "less": {
+            "optional": true
+        },
+        "sass": {
+            "optional": true
+        }
+    },
     "dependencies": {
         "cac": "^6.7.12",
         "color": "^4.0.1",


### PR DESCRIPTION
标记为一个"可选"项，意味着如果缺少它不是错误（`less`、`sass`）
详情可见：https://github.com/npm/cli/issues/1247#issuecomment-729583821
比如我的包管理器是`pnpm`，并且项目只安装了`sass`，在做一些卸载或者重新安装时会报下图警告
<img width="429" alt="image" src="https://user-images.githubusercontent.com/44761321/158635946-ebcea3ee-e38c-44c7-85b3-c466186862f4.png">

